### PR TITLE
Adjust rclone config path

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -11,7 +11,7 @@ rclone_version: "{{ ansible_local.rclone.version | d('0.0.0') }}"
 rclone_setup_tmp_dir: "/tmp/rclone_setup"
 
 # The location to install the config file if configured
-rclone_config_location: "{{ (env == 'development') | ternary('/home/vagrant/.config/rclone/rclone.conf','/home/web/.config/rclone/rclone.conf') }}"
+rclone_config_location: "{{ (env == 'development') | ternary('/home/vagrant/.config/rclone/rclone.conf','/opt/rclone/rclone.conf') }}"
 
 install_manpages: true
 


### PR DESCRIPTION
We need to put the `rclone.conf` in a location available to all users vs. tying it to the **web**-user (who doesn't run the cron jobs...)